### PR TITLE
Refactoring to get closer to an overview

### DIFF
--- a/mvp-spec/README.md
+++ b/mvp-spec/README.md
@@ -1,28 +1,10 @@
 # Prebid Addressability Framework
 
-This directory contains functional and technical specifications for PAF minimum viable product (MVP). 
+The Prebid Addressability Framework (PAF) is a set of technical standards, UX requirements, and mandatory contractual terms designed to improve addressable advertising across the open internet.
 
-## Documents
+This directory contains functional andPAF technical specifications for PAFa minimum viable product (MVP)
 
-| Document                                                                   | Description                                                                                         |
-|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
-| [signatures.md](signatures.md)                                             | General introduction on signatures and signature verification                                       |
-| [audit-log-requirements.md](audit-log-requirements.md)                     | Functional requirements related to the Audit Log and the Transmissions.                             |
-| [audit-log-design.md](audit-log-design.md)                                 | Design the technical solution for the Audit Log.                                                    |
-| [ad-server-implementation.md](ad-server-implementation.md)                 | Details PAF implementation in an Ad Server.                                                         |
-| [dsp-implementation.md](dsp-implementation.md)                             | Data exchange specification, from the point of view of a DSP implementer.                           |
-| [operator-api.md](operator-api.md)                                         | Operator API specification                                                                          |
-| [operator-design.md](operator-design.md)                                   | Design of the generation of Prebid SSO Data.                                                        |
-| [operator-design-alternative-swan.md](operator-design-alternative-swan.md) | Summary of the SWAN solution for generating PAF Data.                                               |
-| [operator-requirements.md](operator-requirements.md)                       | Requirements for the generation of the PAF Data.                                                    |
-| [operator-client.md](operator-client.md)                                   | Modules needed to connect to the operator                                                           |
-| [model/](model)                                                            | Data and messages model                                                                             |
-| [json-schemas/](json-schemas)                                              | Data and messages model in [JSON schema](https://json-schema.org/understanding-json-schema/) format |
-| `assets/` `model-updater/` `partials/` `partials-updater/`                 | Technical dependencies, please ignore                                                               |
-
-## Architecture
-
-PAF integrates in the existing digital marketing landscape and introduces a new actor: the "PAF operator".
+## Overview
 
 ```mermaid
 flowchart LR
@@ -54,58 +36,31 @@ flowchart LR
     click UI href "#user-interface-provider" "UI provider"
 ```
 
-## Nodes
-
-### Advertiser website
-
-An advertiser is a client of the operator to read ids and preferences from the visiting user.
-
-See [operator-client.md](operator-client.md) for instructions on implementing the operator client.
-
-### User Interface Provider
-
-User Interface Providers are responsible for gathering **user preferences**.
-
-A clear User Interface must be provided to users and the UI Provider must **sign** preferences before they are **saved**
-by the operator.
-
-Signing and writing preferences is explained in [operator-client.md](operator-client.md).
-
-### Publisher website
-
-The publisher has multiple roles
-
-1. Just like the advertiser, it needs to read id and preferences from the operator
-2. It is also selling inventory to contracting parties and must create and sign a "seed" object and initialize an RTB transaction sent to an SSP
-   1. this is done through the ad server
-
-A publisher is a client of the operator to read ids and preferences from the visiting user.
-
-See [operator-client.md](operator-client.md) for instructions on implementing the operator client.
-
-### Ad server
-
-See [ad-server-implementation.md](ad-server-implementation.md).
-
-### SSP (Supply Side Platform)
-
-The SSP shares PAF Data to DSPs via Transmission Requests. Depending of the context, it can generate the Seed and emit the first Transmission of the Transaction or receive the Seed from a previous Transmission Request.
-
-### DSP (Demand Side Platform)
-
-DSPs receive transmissions that they must sign before they respond to the SSP
-
-See [dsp-implementation.md](dsp-implementation.md).
-
-### Operator
+PAF integrates in the existing digital marketing landscape and introduces a new actor: the "PAF operator".
 
 The operator is responsible for:
-- generating unique user ids
+- generating unique pseudonymous user ids
 - storing these ids and their associated preferences
 
-See [operator-api.md](operator-api.md) for details.
+Key features of PAF include:
 
-### See also
+- signing transmissions and request with private keys
+- making available an ad display audit log
 
-- Focus on [signatures](signatures.md)
-- Audit log [design](audit-log-design.md)
+## Documents
+
+| Document                                                                   | Description                                                                                         |
+|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| [signatures.md](signatures.md)                                             | General introduction on signatures and signature verification                                       |
+| [audit-log-requirements.md](audit-log-requirements.md)                     | Functional requirements related to the Audit Log and the Transmissions.                             |
+| [audit-log-design.md](audit-log-design.md)                                 | Design the technical solution for the Audit Log.                                                    |
+| [ad-server-implementation.md](ad-server-implementation.md)                 | Details PAF implementation in an Ad Server.                                                         |
+| [dsp-implementation.md](dsp-implementation.md)                             | Data exchange specification, from the point of view of a DSP implementer.                           |
+| [operator-api.md](operator-api.md)                                         | Operator API specification                                                                          |
+| [operator-design.md](operator-design.md)                                   | Design of the generation of Prebid SSO Data.                                                        |
+| [operator-design-alternative-swan.md](operator-design-alternative-swan.md) | Summary of the SWAN solution for generating PAF Data.                                               |
+| [operator-requirements.md](operator-requirements.md)                       | Requirements for the generation of the PAF Data.                                                    |
+| [operator-client.md](operator-client.md)                                   | Modules needed to connect to the operator                                                           |
+| [model/](model)                                                            | Data and messages model                                                                             |
+| [json-schemas/](json-schemas)                                              | Data and messages model in [JSON schema](https://json-schema.org/understanding-json-schema/) format |
+| `assets/` `model-updater/` `partials/` `partials-updater/`                 | Technical dependencies, please ignore                                                               |

--- a/mvp-spec/README.md
+++ b/mvp-spec/README.md
@@ -1,4 +1,4 @@
-# Prebid Addressability Framework MVP specs
+# Prebid Addressability Framework
 
 This directory contains functional and technical specifications for PAF minimum viable product (MVP). 
 

--- a/mvp-spec/README.md
+++ b/mvp-spec/README.md
@@ -45,7 +45,7 @@ The operator is responsible for:
 - generating unique user ids
 - storing these ids and their associated preferences
 
-See operator-api.md for details.
+See [operator-api.md](operator-api.md)  for details.
 
 ### Participant website
 
@@ -53,7 +53,7 @@ A participant website is usually either an advertiser or publisher website. It c
 - Call the Operator to read the user id and preferences
 - Sell ad placements to other PAF participants. To do so it must create and sign a "seed" object and initialize an RTB transaction sent to an SSP.
 
-See operator-client.md and ad-server-implementation.md.
+See [operator-client.md](operator-client.md) and [ad-server-implementation.md](ad-server-implementation.md).
 
 ### SSP (Supply Side Platform)
 
@@ -63,12 +63,12 @@ The SSP shares PAF Data to DSPs via Transmission Requests. Depending of the cont
 
 DSPs receive transmissions that they must sign before they respond to the SSP
 
-See dsp-implementation.md.
+See d[dsp-implementation.md](dsp-implementation.md).
 
 ### See also
 
-Focus on signatures
-Audit log design
+- Focus on signatures: [signatures.md](signatures.md)
+- Audit log design: [audit-log-design.md](audit-log-design.md)
 
 ## Documents
 

--- a/mvp-spec/README.md
+++ b/mvp-spec/README.md
@@ -12,28 +12,18 @@ flowchart LR
     O(PAF Operator)
     click O href "#operator" "Operator API"
     
-    Ad(Ad server)
-    click Ad href "#ad-server" "Ad server"
+    Participant("Participant website")
     
-    Advertiser("Advertiser website")
-    Advertiser --->|read user ids & preferences| O
-    click Advertiser href "#advertiser" "Advertiser"
+    Participant -->|read user ids & preferences| O
+    click Participant href "#publisher" "Participant"
     
-    Publisher("Publisher website")
-    
-    Publisher -->|read user ids & preferences| O
-    click Publisher href "#publisher" "Publisher"
-    
-    Publisher -.->|include| UI
-    Publisher -- start transaction --> SSP
-    Publisher -- get ad & audit logs --> Ad
-    
+    Participant -- start transaction --> SSP
     SSP -- send transmission --> DSP
+    DSP -- send transmission response --> SSP
+    SSP -- send transmission response --> Participant    
+
     click SSP href "#ssp-supply-side-platform" "SSP"
     click DSP href "#dsp-demand-side-platform" "DSP"
-    
-    UI("User Interface Provider") -->|write user preferences| O
-    click UI href "#user-interface-provider" "UI provider"
 ```
 
 PAF integrates in the existing digital marketing landscape and introduces a new actor: the "PAF operator".
@@ -45,7 +35,7 @@ The operator is responsible for:
 Key features of PAF include:
 
 - signing transmissions and request with private keys
-- making available an ad display audit log
+- making available alongside the ad an audit log of entities involved
 
 ## Documents
 

--- a/mvp-spec/README.md
+++ b/mvp-spec/README.md
@@ -2,7 +2,7 @@
 
 The Prebid Addressability Framework (PAF) is a set of technical standards, UX requirements, and mandatory contractual terms designed to improve addressable advertising across the open internet.
 
-This directory contains functional andPAF technical specifications for PAFa minimum viable product (MVP)
+This directory contains functional and technical specifications for a minimum viable product (MVP).
 
 ## Overview
 

--- a/mvp-spec/README.md
+++ b/mvp-spec/README.md
@@ -37,6 +37,39 @@ Key features of PAF include:
 - signing transmissions and request with private keys
 - making available alongside the ad an audit log of entities involved
 
+## Nodes
+
+### Operator
+
+The operator is responsible for:
+- generating unique user ids
+- storing these ids and their associated preferences
+
+See operator-api.md for details.
+
+### Participant website
+
+A participant website is usually either an advertiser or publisher website. It can:
+- Call the Operator to read the user id and preferences
+- Sell ad placements to other PAF participants. To do so it must create and sign a "seed" object and initialize an RTB transaction sent to an SSP.
+
+See operator-client.md and ad-server-implementation.md.
+
+### SSP (Supply Side Platform)
+
+The SSP shares PAF Data to DSPs via Transmission Requests. Depending of the context, it can generate the Seed and emit the first Transmission of the Transaction or receive the Seed from a previous Transmission Request.
+
+### DSP (Demand Side Platform)
+
+DSPs receive transmissions that they must sign before they respond to the SSP
+
+See dsp-implementation.md.
+
+### See also
+
+Focus on signatures
+Audit log design
+
 ## Documents
 
 | Document                                                                   | Description                                                                                         |


### PR DESCRIPTION
- Added short project description
- Moved diagram to the beginning of the page
- Removed paragraphs redundant with the documents table
- Refocused the diagram on main entities: operator, participant website, SSP, DSP